### PR TITLE
refactor: use command modules

### DIFF
--- a/__tests__/integration/files.test.ts
+++ b/__tests__/integration/files.test.ts
@@ -5,7 +5,7 @@ import { defaultLayers } from "@/constants";
 import { createFiles } from "@/files";
 import { createLayersIfNotExists } from "@/layers";
 
-describe("Layers folders structure", () => {
+describe("Files structure", () => {
 	function getFilePathForLayer(
 		basePath: string,
 		mainFolder: string,

--- a/__tests__/unit/commands.test.ts
+++ b/__tests__/unit/commands.test.ts
@@ -1,0 +1,147 @@
+import { commands } from "@/commands";
+import { defaultLayers, defaultMainDirectory } from "@/constants";
+import * as files from "@/files";
+import * as layers from "@/layers";
+import yargs from "yargs";
+
+describe("Scaffold command", () => {
+	let parser: yargs.Argv;
+	const resources = ["product", "user"];
+
+	beforeEach(() => {
+		parser = yargs.command(commands);
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it("should return help output", async () => {
+		parser.help();
+		const output = await new Promise((resolve, reject) => {
+			parser.parse("--help", {}, (error, _, output) => {
+				if (error) {
+					reject(error);
+				}
+				resolve(output);
+			});
+		});
+		expect(output).toBeDefined();
+	});
+
+	describe("Success", () => {
+		let createLayersSpy: jest.SpyInstance;
+		let createFilesSpy: jest.SpyInstance;
+
+		beforeEach(() => {
+			createLayersSpy = jest
+				.spyOn(layers, "createLayersIfNotExists")
+				.mockResolvedValue([]);
+			createFilesSpy = jest
+				.spyOn(files, "createFiles")
+				.mockResolvedValue({ success: true });
+		});
+
+		it("should scaffold a new resource", async () => {
+			await new Promise((resolve, reject) => {
+				parser.parse(
+					`scaffold ${resources.map((resource) => `-r ${resource}`).join(" ")}`,
+					{},
+					(error, _, output) => {
+						if (error) {
+							reject(error);
+						}
+						resolve(output);
+					},
+				);
+			});
+			expect(createLayersSpy).toHaveBeenCalledWith(
+				process.cwd(),
+				defaultMainDirectory,
+				defaultLayers,
+			);
+			for (const resource of resources) {
+				expect(createFilesSpy).toHaveBeenCalledWith(
+					process.cwd(),
+					defaultMainDirectory,
+					defaultLayers,
+					resource,
+				);
+			}
+		});
+
+		it("should scaffold a new service", async () => {
+			await new Promise((resolve, reject) => {
+				parser.parse(
+					`scaffold -s ${resources.at(0)}`,
+					{},
+					(error, _, output) => {
+						if (error) {
+							reject(error);
+						}
+						resolve(output);
+					},
+				);
+			});
+			expect(createLayersSpy).toHaveBeenCalledWith(
+				process.cwd(),
+				defaultMainDirectory,
+				defaultLayers,
+			);
+			expect(createFilesSpy).toHaveBeenCalledWith(
+				process.cwd(),
+				defaultMainDirectory,
+				["service"].toSorted(),
+				resources.at(0),
+			);
+		});
+
+		it("should not log errors on success", async () => {
+			const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+			await new Promise((resolve, reject) => {
+				parser.parse(
+					`scaffold ${resources.map((resource) => `-r ${resource}`).join(" ")}`,
+					{},
+					(error, _, output) => {
+						if (error) {
+							reject(error);
+						}
+						resolve(output);
+					},
+				);
+			});
+			expect(spy).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("Error", () => {
+		let createLayersSpy: jest.SpyInstance;
+		let createFilesSpy: jest.SpyInstance;
+
+		beforeEach(() => {
+			createLayersSpy = jest
+				.spyOn(layers, "createLayersIfNotExists")
+				.mockResolvedValue([]);
+			createFilesSpy = jest
+				.spyOn(files, "createFiles")
+				.mockResolvedValue({ success: false, message: "An error occurred." });
+		});
+
+		it("should catch and log the error", async () => {
+			const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+			await new Promise((resolve, reject) => {
+				parser.parse(
+					`scaffold ${resources.map((resource) => `-r ${resource}`).join(" ")}`,
+					{},
+					(error, _, output) => {
+						if (error) {
+							reject(error);
+						}
+						resolve(output);
+					},
+				);
+			});
+			expect(spy).toHaveBeenCalledWith("Error: ", "An error occurred.");
+		});
+	});
+});

--- a/__tests__/unit/files.test.ts
+++ b/__tests__/unit/files.test.ts
@@ -24,7 +24,8 @@ describe("Files structure", () => {
 
 	it("should not create a file structure on inexistent layers", async () => {
 		const expected = {
-			error: `Template for layer "infrastructure" not found.`,
+			message: `Template for layer "infrastructure" not found.`,
+			success: false,
 		};
 		const result = await createFiles(
 			"",
@@ -67,7 +68,8 @@ describe("Files structure", () => {
 		jest.spyOn(fsPromises, "writeFile").mockRejectedValue(error);
 
 		const expected = {
-			error: error.message,
+			message: error.message,
+			success: false,
 		};
 
 		const result = await createFiles("", "src", ["repository"], resource);

--- a/__tests__/unit/utils/files.test.ts
+++ b/__tests__/unit/utils/files.test.ts
@@ -1,0 +1,20 @@
+import fsPromises from "node:fs/promises";
+import os from "node:os";
+import { getDefaultMainDirectory } from "@/utils/files";
+
+describe("getDefaultMainDirectory", () => {
+	it("should return the default main directory", async () => {
+		const result = await getDefaultMainDirectory();
+		expect(result).toBe("src");
+	});
+
+	it("should return a temporary directory when in development mode", async () => {
+		process.env.NODE_ENV = "dev";
+		jest.spyOn(os, "tmpdir").mockReturnValue("/tmp");
+		jest
+			.spyOn(fsPromises, "mkdtemp")
+			.mockResolvedValue("/tmp/regen-integration-1234");
+		const result = await getDefaultMainDirectory();
+		expect(result).toContain("regen-integration-");
+	});
+});

--- a/__tests__/unit/utils/tags.test.ts
+++ b/__tests__/unit/utils/tags.test.ts
@@ -12,7 +12,7 @@ describe("tags", () => {
 				["lower", "lower case"],
 				[undefined, "undefined case"],
 				[null, ""],
-			] as [Casing, string][]) {
+			] as [Template.Casing, string][]) {
 				const result = template`${{
 					value: expected ? `${casing} case` : null,
 					casing,

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,0 +1,3 @@
+import scaffold from "./scaffold";
+
+export const commands = [scaffold];

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,3 +1,5 @@
 export const defaultMainDirectory = "src";
 
-export const defaultLayers = ["service", "repository", "factory"].sort();
+export const defaultLayers: Layer[] = ["factory", "repository", "service"];
+
+export const basePath = process.env.NODE_ENV === "dev" ? "" : process.cwd();

--- a/src/files/index.ts
+++ b/src/files/index.ts
@@ -24,7 +24,10 @@ export async function createFiles(
 			keys.find((key) => key.includes(layer)) || "",
 		);
 		if (!component) {
-			return { error: `Template for layer "${layer}" not found.` };
+			return {
+				success: false,
+				message: `Template for layer "${layer}" not found.`,
+			};
 		}
 
 		const folderPath = `${basePath}/${defaultMainDirectory}/${layer}`;
@@ -35,7 +38,7 @@ export async function createFiles(
 	try {
 		await Promise.all(promises);
 	} catch (error) {
-		return { error: (error as Error).message };
+		return { success: false, message: (error as Error).message };
 	}
 
 	return { success: true };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,52 +1,7 @@
 #!/usr/bin/env node
 
-import fsPromises from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { commands } from "@/commands";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { defaultLayers } from "./constants";
-import { createFiles } from "./files";
-import { createLayersIfNotExists } from "./layers";
 
-const { argv } = yargs(hideBin(process.argv)).command(
-	"scaffold",
-	"Scaffold a new resource in your project.",
-	(yargs) => {
-		yargs
-			.option("resource", {
-				alias: "r",
-				type: "array",
-				description: "The name of the resource to scaffold",
-				demandOption: true,
-			})
-			.example(
-				"scaffold -r product",
-				'Scaffold a project with a single "product" domain',
-			)
-			.example(
-				"scaffold -r product -r user",
-				'Scaffold a project with two domains: "product" and "user"',
-			)
-			.epilog("For more information, visit the documentation.");
-	},
-);
-
-const defaultMainDirectory =
-	process.env.NODE_ENV === "dev"
-		? await fsPromises.mkdtemp(join(tmpdir(), "regen-integration-"))
-		: "src";
-const basePath = process.env.NODE_ENV === "dev" ? "" : process.cwd();
-
-await createLayersIfNotExists(basePath, defaultMainDirectory, defaultLayers);
-
-try {
-	await Promise.all(
-		((await argv).resource as string[]).map(async (resource: string) => {
-			createFiles(basePath, defaultMainDirectory, defaultLayers, resource);
-		}),
-	);
-} catch (error) {
-	console.error("An error occurred while scaffolding the resource.");
-	console.error(error);
-}
+yargs(hideBin(process.argv)).command(commands).parse();

--- a/src/templates/factory.ts
+++ b/src/templates/factory.ts
@@ -21,8 +21,11 @@ export default class ${{ value: resource, casing: "pascal" }}Factory {
 `;
 }
 
-function filename(resource: string) {
-	return template`${{ value: resource, casing: "kebab" }}.factory.ts`;
+function filename(
+	resource: string,
+	casing: Extract<Template.Casing, "kebab" | "camel"> = "kebab",
+) {
+	return template`${{ value: resource, casing: casing }}.factory.ts`;
 }
 
 function name(resource: string) {

--- a/src/templates/repository.ts
+++ b/src/templates/repository.ts
@@ -23,7 +23,7 @@ function body(resource: string) {
 `;
 }
 
-function filename(resource: string, casing: Casing = "kebab") {
+function filename(resource: string, casing: Template.Casing = "kebab") {
 	return template`${{ value: resource, casing: casing }}.repository.ts`;
 }
 

--- a/src/templates/service.ts
+++ b/src/templates/service.ts
@@ -37,7 +37,10 @@ export default class ${{ value: resource, casing: "pascal" }}Service {
 `;
 }
 
-function filename(resource: string, casing: "kebab" | "snake" = "kebab") {
+function filename(
+	resource: string,
+	casing: Extract<Template.Casing, "kebab" | "camel"> = "kebab",
+) {
 	return template`${{
 		value: resource,
 		casing: casing,

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -10,11 +10,15 @@ interface Component {
 	body: string;
 }
 
-type Casing = "camel" | "pascal" | "kebab" | "snake" | "upper" | "lower";
+declare namespace Template {
+	type Casing = "camel" | "pascal" | "kebab" | "snake" | "upper" | "lower";
 
-type Value = object | string | number | boolean | null | undefined;
+	type Value = object | string | number | boolean | null | undefined;
 
-type Placeholder = {
-	value: Value;
-	casing?: Casing;
-};
+	type Placeholder = {
+		value: Value;
+		casing?: Casing;
+	};
+}
+
+type Layer = "service" | "repository" | "factory";

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -1,0 +1,9 @@
+import fsPromises from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export async function getDefaultMainDirectory() {
+	return process.env.NODE_ENV === "dev"
+		? await fsPromises.mkdtemp(join(tmpdir(), "regen-integration-"))
+		: "src";
+}

--- a/src/utils/tags.ts
+++ b/src/utils/tags.ts
@@ -10,7 +10,7 @@
  */
 export function template(
 	strings: TemplateStringsArray,
-	...placeholders: Placeholder[]
+	...placeholders: Template.Placeholder[]
 ): string {
 	const result = [strings[0]];
 	placeholders.forEach((placeholder, i) => {


### PR DESCRIPTION
This PR solves [this issue](https://github.com/William-Fernandes252/regen/issues/2) by refactoring the "scaffold" command into a separate module, thus creating a standard for the upcoming commands.