### PR TITLE
Allow users to pass the base and project main directory as options

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,20 @@ Scaffold a new resource in your project.
 
 ```bash
 Options:
-      --help      Show help                                            [boolean]
-      --version   Show version number                                  [boolean]
-  -r, --resource  The name of the resource to scaffold        [array] [required]
+      --help        Show help                                          [boolean]
+      --version     Show version number                                [boolean]
+  -r, --resource    The name of the resource to scaffold   [array] [default: []]
+  -s, --service     The name of the service to scaffold    [array] [default: []]
+  -p, --repository  The name of the repository to scaffold [array] [default: []]
+  -b, --base-dir    The base directory for the project    [string] [default: ""]
+  -m, --main-dir    The main directory for the project [string] [default: "src"]
 
 Examples:
   scaffold -r product          Scaffold a project with a single "product" domain
   scaffold -r product -r user  Scaffold a project with two domains: "product" an
                                d "user"
+  scaffold -s product          Scaffold a project with a single "product" servic
+                               e
+
+For more information, visit the documentation.
 ```

--- a/__tests__/unit/commands.test.ts
+++ b/__tests__/unit/commands.test.ts
@@ -42,7 +42,7 @@ describe("Scaffold command", () => {
 				.mockResolvedValue({ success: true });
 		});
 
-		it("should scaffold a new resource", async () => {
+		it("should scaffold a new resource in the default main directory", async () => {
 			await new Promise((resolve, reject) => {
 				parser.parse(
 					`scaffold ${resources.map((resource) => `-r ${resource}`).join(" ")}`,
@@ -64,6 +64,40 @@ describe("Scaffold command", () => {
 				expect(createFilesSpy).toHaveBeenCalledWith(
 					process.cwd(),
 					defaultMainDirectory,
+					defaultLayers,
+					resource,
+				);
+			}
+		});
+
+		it("should scaffold a new resource in the user defined main directory", async () => {
+			const customMainDirectory = "src/app";
+			const customBaseDirectory = "/home/user/projects/my-app";
+
+			await new Promise((resolve, reject) => {
+				parser.parse(
+					`scaffold -m ${customMainDirectory} -b ${customBaseDirectory} ${resources
+						.map((resource) => `-r ${resource}`)
+						.join(" ")}`,
+					{},
+					(error, _, output) => {
+						if (error) {
+							reject(error);
+						}
+						resolve(output);
+					},
+				);
+			});
+
+			expect(createLayersSpy).toHaveBeenCalledWith(
+				customBaseDirectory,
+				customMainDirectory,
+				defaultLayers,
+			);
+			for (const resource of resources) {
+				expect(createFilesSpy).toHaveBeenCalledWith(
+					customBaseDirectory,
+					customMainDirectory,
 					defaultLayers,
 					resource,
 				);

--- a/src/commands/scaffold.ts
+++ b/src/commands/scaffold.ts
@@ -8,11 +8,15 @@ import { basePath, defaultLayers } from "../constants";
  * @property {Array} resource The name of the resource to scaffold
  * @property {Array} service The name of the service to scaffold
  * @property {Array} repository The name of the repository to scaffold
+ * @property {string} baseDir The base directory for the project
+ * @property {string} mainDir The main directory for the project
  */
 type A = {
 	resource: string[];
 	service: string[];
 	repository: string[];
+	"base-dir": string;
+	"main-dir": string;
 };
 
 const command = "scaffold";
@@ -40,6 +44,18 @@ const builder = (yargs: yargs.Argv) =>
 			description: "The name of the repository to scaffold",
 			default: [],
 		})
+		.option("base-dir", {
+			alias: "b",
+			type: "string",
+			description: "The base directory for the project",
+			default: basePath,
+		})
+		.option("main-dir", {
+			alias: "m",
+			type: "string",
+			description: "The main directory for the project",
+			default: "src",
+		})
 		.example(
 			"scaffold -r product",
 			'Scaffold a project with a single "product" domain',
@@ -57,19 +73,28 @@ const builder = (yargs: yargs.Argv) =>
 const handler = async (args: yargs.ArgumentsCamelCase<A>): Promise<void> => {
 	const defaultMainDirectory = await getDefaultMainDirectory();
 
-	await createLayersIfNotExists(basePath, defaultMainDirectory, defaultLayers);
+	await createLayersIfNotExists(
+		args["base-dir"],
+		args["main-dir"],
+		defaultLayers,
+	);
 
 	const results = await Promise.all([
 		...args.resource.map(async (resource) => {
 			return createFiles(
-				basePath,
-				defaultMainDirectory,
+				args["base-dir"],
+				args["main-dir"],
 				defaultLayers,
 				resource,
 			);
 		}),
 		...args.service.map(async (service) => {
-			return createFiles(basePath, defaultMainDirectory, ["service"], service);
+			return createFiles(
+				args["base-dir"],
+				args["main-dir"],
+				["service"],
+				service,
+			);
 		}),
 	]);
 


### PR DESCRIPTION
This PR solves [this issue](https://github.com/William-Fernandes252/regen/issues/4) by adding the corresponding options in the scaffold command.