### PR TITLE
Clean template implementation to make it more closed to change

### DIFF
--- a/__tests__/integration/layers.test.ts
+++ b/__tests__/integration/layers.test.ts
@@ -1,13 +1,13 @@
 import fsPromises from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { defaultLayers } from "@/constants";
+import { basePath as defaultBasePath, defaultLayers } from "@/constants";
 import { createLayersIfNotExists } from "@/layers";
 
 describe("Layers folders structure", () => {
 	const defaultMainDirectory = "src";
 
-	let basePath: string;
+	let basePath: string = defaultBasePath;
 
 	async function getFolders(...paths: string[]) {
 		return await fsPromises.readdir(join(...paths));

--- a/__tests__/unit/templates.test.ts
+++ b/__tests__/unit/templates.test.ts
@@ -1,4 +1,5 @@
 import templates from "@/templates";
+import { Kebab, Pascal } from "@/utils/formats";
 import { template } from "@/utils/tags";
 import {
 	factoryTemplateMock,
@@ -15,9 +16,9 @@ describe("Code generation", () => {
 
 	it("should generate a repository template", () => {
 		const expected: Component = {
-			filename: template`${{ value: resource, casing: "kebab" }}.repository.ts`,
+			filename: template`${new Kebab(resource)}.repository.ts`(),
 			body: repositoryTemplateMock,
-			name: template`${{ value: resource, casing: "pascal" }}Repository`,
+			name: template`${new Pascal(resource)}Repository`(),
 		};
 
 		const result = templates.get("repository")?.(resource);
@@ -28,53 +29,41 @@ describe("Code generation", () => {
 
 	it("should generate a service template", () => {
 		const expected: Component = {
-			filename: template`${{ value: resource, casing: "kebab" }}.service.ts`,
+			filename: template`${new Kebab(resource)}.service.ts`(),
 			body: serviceTemplateMock,
-			name: template`${{ value: resource, casing: "pascal" }}Service`,
+			name: template`${new Pascal(resource)}Service`(),
 		};
 
 		const result = templates.get("service")?.(resource);
 
 		expect(result).toEqual(expected);
 		expect(result?.body).toContain(
-			template`import ${{
-				value: resource,
-				casing: "pascal",
-			}}Repository from "../repository/${{
-				value: resource,
-				casing: "kebab",
-			}}.repository";`,
+			template`import ${new Pascal(
+				resource,
+			)}Repository from "../repository/${new Kebab(resource)}.repository";`(),
 		);
 		expect(result?.body).toContain(`export default class ${result?.name}`);
 	});
 
 	it("should generate a factory template", () => {
 		const expected: Component = {
-			filename: template`${{ value: resource, casing: "kebab" }}.factory.ts`,
+			filename: template`${new Kebab(resource)}.factory.ts`(),
 			body: factoryTemplateMock,
-			name: template`${{ value: resource, casing: "pascal" }}Factory`,
+			name: template`${new Pascal(resource)}Factory`(),
 		};
 
 		const result = templates.get("factory")?.(resource);
 
 		expect(result).toEqual(expected);
 		expect(result?.body).toContain(
-			template`import ${{
-				value: resource,
-				casing: "pascal",
-			}}Repository from "../repository/${{
-				value: resource,
-				casing: "kebab",
-			}}.repository";`,
+			template`import ${new Pascal(
+				resource,
+			)}Repository from "../repository/${new Kebab(resource)}.repository";`(),
 		);
 		expect(result?.body).toContain(
-			template`import ${{
-				value: resource,
-				casing: "pascal",
-			}}Service from "../service/${{
-				value: resource,
-				casing: "kebab",
-			}}.service";`,
+			template`import ${new Pascal(
+				resource,
+			)}Service from "../service/${new Kebab(resource)}.service";`(),
 		);
 		expect(result?.body).toContain(`export default class ${result?.name}`);
 	});

--- a/__tests__/unit/utils/formats.test.ts
+++ b/__tests__/unit/utils/formats.test.ts
@@ -1,0 +1,64 @@
+import { Camel, Kebab, Lower, Pascal, Snake, Upper } from "@/utils/formats";
+
+describe("formats", () => {
+	const cases = [
+		{
+			Class: Upper,
+			input: "hello world",
+			expected: "HELLO WORLD",
+		},
+		{
+			Class: Lower,
+			input: "HELLO WORLD",
+			expected: "hello world",
+		},
+		{
+			Class: Camel,
+			input: "hello world",
+			expected: "helloWorld",
+		},
+		{
+			Class: Pascal,
+			input: "hello world",
+			expected: "HelloWorld",
+		},
+		{
+			Class: Kebab,
+			input: "hello world",
+			expected: "hello-world",
+		},
+		{
+			Class: Snake,
+			input: "hello world",
+			expected: "hello_world",
+		},
+	];
+
+	it.each(cases)(
+		"$Class.name should format '$input' correctly",
+		({ Class, input, expected }) => {
+			const instance = new Class(input);
+			expect(instance.toString()).toBe(expected);
+		},
+	);
+
+	it("should support symbol-toPrimitive for string coercion", () => {
+		const instance = new Pascal("hello world");
+		expect(`${instance}`).toBe("HelloWorld");
+	});
+
+	it("should handle multiple delimiters", () => {
+		const snake = new Snake("this--is__a test");
+		const kebab = new Kebab("this--is__a test");
+		const camel = new Camel("this--is__a test");
+
+		expect(snake.toString()).toBe("this_is_a_test");
+		expect(kebab.toString()).toBe("this-is-a-test");
+		expect(camel.toString()).toBe("thisIsATest");
+	});
+
+	it("should return empty string for undefined or null values", () => {
+		expect(new Upper(undefined).toString()).toBe("");
+		expect(new Kebab(null).toString()).toBe("");
+	});
+});

--- a/__tests__/unit/utils/tags.test.ts
+++ b/__tests__/unit/utils/tags.test.ts
@@ -1,32 +1,56 @@
+import {
+	Camel,
+	type Case,
+	Kebab,
+	Lower,
+	Pascal,
+	Snake,
+	Upper,
+} from "@/utils/formats";
 import { template } from "@/utils/tags";
 
 describe("tags", () => {
 	describe("template", () => {
 		it("should parse a placeholder based on the given values", () => {
-			for (const [casing, expected] of [
-				["camel", "camelCase"],
-				["pascal", "PascalCase"],
-				["kebab", "kebab-case"],
-				["snake", "snake_case"],
-				["upper", "UPPER CASE"],
-				["lower", "lower case"],
-				[undefined, "undefined case"],
-				[null, ""],
-			] as [Template.Casing, string][]) {
-				const result = template`${{
-					value: expected ? `${casing} case` : null,
-					casing,
-				}}`;
+			for (const [Format, expected] of [
+				[Camel, "camelCase"],
+				[Pascal, "PascalCase"],
+				[Kebab, "kebab-case"],
+				[Snake, "snake_case"],
+				[Upper, "UPPER CASE"],
+				[Lower, "lower case"],
+			] as [new (value: string) => Case, string][]) {
+				const result = template`${new Format(`${Format.name} case`)}`();
 				expect(result).toStrictEqual(expected);
 			}
 		});
 
+		it("should ignore falsy values", () => {
+			const result = template`${new Pascal(
+				"user",
+			)}${undefined}${null}Repository`();
+			expect(result).toStrictEqual("UserRepository");
+		});
+
 		it("should work as the example", () => {
-			const result = template`class ${{
-				value: "user",
-				casing: "pascal",
-			}}Repository {}`;
+			const result = template`class ${new Pascal("user")}Repository {}`();
 			expect(result).toStrictEqual("class UserRepository {}");
+		});
+
+		describe("compose", () => {
+			it("should compose the result with a function", () => {
+				const result = template`${new Pascal("user")}Repository`.compose(
+					(input) => `${input}Test`,
+				)();
+				expect(result).toStrictEqual("UserRepositoryTest");
+			});
+
+			it("should return the composed value when calling thenRender", () => {
+				const result = template`${new Pascal("user")}Repository`
+					.compose((input) => `${input}Test`)
+					.thenRender();
+				expect(result).toStrictEqual("UserRepositoryTest");
+			});
 		});
 	});
 });

--- a/src/templates/factory.ts
+++ b/src/templates/factory.ts
@@ -1,35 +1,26 @@
+import { Kebab, Pascal } from "@/utils/formats";
 import { template } from "@/utils/tags";
 
 function body(resource: string) {
-	return template`import ${{
-		value: resource,
-		casing: "pascal",
-	}}Repository from "../repository/${{ value: resource, casing: "kebab" }}.repository";
-import ${{ value: resource, casing: "pascal" }}Service from "../service/${{
-		value: resource,
-		casing: "kebab",
-	}}.service";
+	return template`import ${new Pascal(
+		resource,
+	)}Repository from "../repository/${new Kebab(resource)}.repository";
+import ${new Pascal(resource)}Service from "../service/${new Kebab(resource)}.service";
 
-export default class ${{ value: resource, casing: "pascal" }}Factory {
+export default class ${new Pascal(resource)}Factory {
   static getInstance() {
-    return new ${{ value: resource, casing: "pascal" }}Service(new ${{
-			value: resource,
-			casing: "pascal",
-		}}Repository());
+    return new ${new Pascal(resource)}Service(new ${new Pascal(resource)}Repository());
   }
 }
 `;
 }
 
-function filename(
-	resource: string,
-	casing: Extract<Template.Casing, "kebab" | "camel"> = "kebab",
-) {
-	return template`${{ value: resource, casing: casing }}.factory.ts`;
+function filename(resource: string) {
+	return template`${new Kebab(resource)}.factory.ts`;
 }
 
 function name(resource: string) {
-	return template`${{ value: resource, casing: "pascal" }}Factory`;
+	return template`${new Pascal(resource)}Factory`;
 }
 
 /**
@@ -40,8 +31,8 @@ function name(resource: string) {
  */
 export function component(resource: string): Component {
 	return {
-		name: name(resource),
-		filename: filename(resource),
-		body: body(resource),
+		name: name(resource).render(),
+		filename: filename(resource).render(),
+		body: body(resource).render(),
 	};
 }

--- a/src/templates/repository.ts
+++ b/src/templates/repository.ts
@@ -1,7 +1,8 @@
+import { Kebab, Pascal } from "@/utils/formats";
 import { template } from "@/utils/tags";
 
 function body(resource: string) {
-	return template`export default class ${{ value: resource, casing: "pascal" }}Repository {
+	return template`export default class ${new Pascal(resource)}Repository {
 	constructor() {}
 
 	async create(data: any) {
@@ -23,12 +24,12 @@ function body(resource: string) {
 `;
 }
 
-function filename(resource: string, casing: Template.Casing = "kebab") {
-	return template`${{ value: resource, casing: casing }}.repository.ts`;
+function filename(resource: string) {
+	return template`${new Kebab(resource)}.repository.ts`;
 }
 
 function name(resource: string) {
-	return template`${{ value: resource, casing: "pascal" }}Repository`;
+	return template`${new Pascal(resource)}Repository`;
 }
 
 /**
@@ -39,8 +40,8 @@ function name(resource: string) {
  */
 export function component(resource: string): Component {
 	return {
-		name: name(resource),
-		filename: filename(resource),
-		body: body(resource),
+		name: name(resource).render(),
+		filename: filename(resource).render(),
+		body: body(resource).render(),
 	};
 }

--- a/src/templates/service.ts
+++ b/src/templates/service.ts
@@ -1,57 +1,41 @@
+import { Camel, Kebab, Pascal } from "@/utils/formats";
 import { template } from "@/utils/tags";
 
 function body(resource: string) {
-	return template`import ${{
-		value: resource,
-		casing: "pascal",
-	}}Repository from "../repository/${{
-		value: resource,
-		casing: "kebab",
-	}}.repository";
+	return template`import ${new Pascal(
+		resource,
+	)}Repository from "../repository/${new Kebab(resource)}.repository";
 
-export default class ${{ value: resource, casing: "pascal" }}Service {
-	constructor(private readonly ${{
-		value: resource,
-		casing: "camel",
-	}}Repository: ${{
-		value: resource,
-		casing: "pascal",
-	}}Repository) {}
+export default class ${new Pascal(resource)}Service {
+	constructor(private readonly ${new Camel(resource)}Repository: ${new Pascal(
+		resource,
+	)}Repository) {}
 
 	async create(data: any) {
-		return this.${{ value: resource, casing: "camel" }}Repository.create(data);
+		return this.${new Camel(resource)}Repository.create(data);
 	}
 
 	async update(id: number, data: any) {
-		return this.${{ value: resource, casing: "camel" }}Repository.update(id, data);
+		return this.${new Camel(resource)}Repository.update(id, data);
 	}
 
 	async delete(id: number) {
-		return this.${{ value: resource, casing: "camel" }}Repository.delete(id);
+		return this.${new Camel(resource)}Repository.delete(id);
 	}
 
 	async read(id: number) {
-		return this.${{ value: resource, casing: "camel" }}Repository.read(id);
+		return this.${new Camel(resource)}Repository.read(id);
 	}
 }
 `;
 }
 
-function filename(
-	resource: string,
-	casing: Extract<Template.Casing, "kebab" | "camel"> = "kebab",
-) {
-	return template`${{
-		value: resource,
-		casing: casing,
-	}}.service.ts`;
+function filename(resource: string) {
+	return template`${new Kebab(resource)}.service.ts`;
 }
 
 function name(resource: string) {
-	return template`${{
-		value: resource,
-		casing: "pascal",
-	}}Service`;
+	return template`${new Pascal(resource)}Service`;
 }
 
 /**
@@ -62,8 +46,8 @@ function name(resource: string) {
  */
 export function component(resource: string): Component {
 	return {
-		name: name(resource),
-		filename: filename(resource),
-		body: body(resource),
+		name: name(resource).render(),
+		filename: filename(resource).render(),
+		body: body(resource).render(),
 	};
 }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,9 +1,3 @@
-/**
- * @interface Component
- * @property {string} class - The class name of the component.
- * @property {string} filename - The filename of the component.
- * @property {string} template - The template of the component.
- */
 interface Component {
 	name: string;
 	filename: string;
@@ -11,14 +5,28 @@ interface Component {
 }
 
 declare namespace Template {
-	type Casing = "camel" | "pascal" | "kebab" | "snake" | "upper" | "lower";
+	type Value = string | number | boolean | null | undefined;
 
-	type Value = object | string | number | boolean | null | undefined;
+	interface Result {
+		/**
+		 * Call the `render` method to get the resulting template.
+		 */
+		(): string;
 
-	type Placeholder = {
-		value: Value;
-		casing?: Casing;
-	};
+		/**
+		 * Render the template with the given placeholders.
+		 */
+		render(): string;
+
+		/**
+		 * Compose the template with the given function.
+		 *
+		 * This function will be called with the rendered template as input.
+		 *
+		 * @template U - The type of the result of the next function.
+		 */
+		compose<U>(next: (input: string) => U): Result & { thenRender: () => U };
+	}
 }
 
 type Layer = "service" | "repository" | "factory";

--- a/src/utils/formats.ts
+++ b/src/utils/formats.ts
@@ -1,0 +1,75 @@
+export abstract class Case {
+	constructor(private raw: Template.Value) {}
+
+	protected getValue(): string {
+		return String(this.raw ?? "");
+	}
+
+	/**
+	 * Convert the value to a formatted string.
+	 */
+	abstract toString(): string;
+
+	[Symbol.toPrimitive](_: string): string {
+		return this.toString();
+	}
+}
+
+export class Upper extends Case {
+	toString(): string {
+		return this.getValue().toUpperCase();
+	}
+}
+
+export class Lower extends Case {
+	toString(): string {
+		return this.getValue().toLowerCase();
+	}
+}
+
+export class Camel extends Case {
+	toString(): string {
+		return this.getValue()
+			.toLowerCase()
+			.split(/[^a-zA-Z0-9]+/)
+			.map((word, index) => {
+				if (index === 0) {
+					return word;
+				}
+				return word.charAt(0).toUpperCase() + word.slice(1);
+			})
+			.join("");
+	}
+}
+
+export class Pascal extends Case {
+	toString(): string {
+		return this.getValue()
+			.toLowerCase()
+			.split(/[^a-zA-Z0-9]+/)
+			.map((word) => {
+				return word.charAt(0).toUpperCase() + word.slice(1);
+			})
+			.join("");
+	}
+}
+
+export class Kebab extends Case {
+	toString(): string {
+		return this.getValue()
+			.toLowerCase()
+			.split(/[^a-zA-Z0-9]+/)
+			.filter((word) => word.length > 0)
+			.join("-");
+	}
+}
+
+export class Snake extends Case {
+	toString(): string {
+		return this.getValue()
+			.toLowerCase()
+			.split(/[^a-zA-Z0-9]+/)
+			.filter((word) => word.length > 0)
+			.join("_");
+	}
+}

--- a/src/utils/tags.ts
+++ b/src/utils/tags.ts
@@ -1,74 +1,57 @@
+import type { Case } from "./formats";
+
 /**
- * Return a string interpolated with the given values formatted.
+ * Return a template literal tag function that can be used to render a component.
  *
  * @param strings The strings of the template literal
  * @param placeholders The placeholders on the template literal
  * @returns A function that will parse the placeholders based on the given values
+ *
  * @example
  * const repository = template`class ${{ value: "product", case: "pascal"}}Repository {}`
  * console.log(repository()) // class ProductRepository {}
  */
 export function template(
 	strings: TemplateStringsArray,
-	...placeholders: Template.Placeholder[]
-): string {
-	const result = [strings[0]];
-	placeholders.forEach((placeholder, i) => {
-		const value = (placeholder.value || "").toString();
-		switch (placeholder.casing) {
-			case "camel":
-				result.push(
-					value
-						.toLowerCase()
-						.split(/[^a-zA-Z0-9]+/)
-						.map((word, index) => {
-							if (index === 0) {
-								return word;
-							}
-							return word.charAt(0).toUpperCase() + word.slice(1);
-						})
-						.join(""),
-				);
-				break;
-			case "pascal":
-				result.push(
-					value
-						.toLowerCase()
-						.split(/[^a-zA-Z0-9]+/)
-						.map((word) => {
-							return word.charAt(0).toUpperCase() + word.slice(1);
-						})
-						.join(""),
-				);
-				break;
-			case "kebab":
-				result.push(
-					value
-						.toLowerCase()
-						.split(/[^a-zA-Z0-9]+/)
-						.filter((word) => word.length > 0)
-						.join("-"),
-				);
-				break;
-			case "snake":
-				result.push(
-					value
-						.toLowerCase()
-						.split(/[^a-zA-Z0-9]+/)
-						.filter((word) => word.length > 0)
-						.join("_"),
-				);
-				break;
-			case "upper":
-				result.push(value.toUpperCase());
-				break;
-			case "lower":
-				result.push(value.toLowerCase());
-				break;
-			default:
-				result.push(value);
-		}
-		result.push(strings[i + 1]);
-	});
-	return result.join("");
+	...placeholders: Array<Case | string | undefined | null>
+): Template.Result {
+	const result: string[] = [];
+
+	function clean() {
+		result.length = 0;
+	}
+
+	function doRender() {
+		clean();
+		result.push(strings[0]);
+		placeholders.forEach((placeholder, i) => {
+			const value = (placeholder || "").toString();
+			result.push(value);
+			result.push(strings[i + 1]);
+		});
+		return result.join("");
+	}
+
+	const methods = {
+		render: () => doRender(),
+		compose: <U>(next: (input: string) => U) => {
+			const composed = () => next(doRender());
+			return Object.assign(composed, {
+				thenRender: () => next(doRender()),
+			});
+		},
+	} as const;
+
+	const handler: ProxyHandler<() => string> = {
+		apply(_target, _thisArg, _args) {
+			return doRender();
+		},
+		get(_target, prop) {
+			if (prop in methods) {
+				return methods[prop as keyof typeof methods];
+			}
+		},
+	};
+
+	return new Proxy(() => doRender(), handler) as Template.Result;
 }


### PR DESCRIPTION
## 📌 Objective

Refactor the [`template`](src/utils/tags.ts) method to mke it more clean.

## 📝 Changes

Use instances of the following class instead of inline objects on the temples to allow it to be smaller and more focused on rendering the components.

```typescript
export abstract class Case {
	constructor(private raw: Template.Value) {}

	protected getValue(): string {
		return String(this.raw ?? "");
	}

	/**
	 * Convert the value to a formatted string.
	 */
	abstract toString(): string;

	[Symbol.toPrimitive](_: string): string {
		return this.toString();
	}
}

// updated signature
function template(
	strings: TemplateStringsArray,
	...placeholders: Array<Case | string | undefined | null>
): Template.Result
```